### PR TITLE
Changed to use comments table id as primarykey

### DIFF
--- a/src/Vendr.Contrib.Reviews/Migrations/V_1_0_0/CreateReviewCommentTable.cs
+++ b/src/Vendr.Contrib.Reviews/Migrations/V_1_0_0/CreateReviewCommentTable.cs
@@ -25,7 +25,7 @@ namespace Vendr.Contrib.Reviews.Migrations.V_1_0_0
 
                 // Create table
                 Create.Table(commentTableName)
-                    .WithColumn("id").AsGuid().NotNullable().WithDefault(SystemMethods.NewGuid).PrimaryKey($"PK_{reviewTableName}")
+                    .WithColumn("id").AsGuid().NotNullable().WithDefault(SystemMethods.NewGuid).PrimaryKey($"PK_{commentTableName}")
                     .WithColumn("storeId").AsGuid().NotNullable()
                     .WithColumn("reviewId").AsGuid().NotNullable()
                     .WithColumn("body").AsCustom(nvarcharMaxType).NotNullable()


### PR DESCRIPTION
The reviews comment table PK should be set to the comments table name not the reviews table name.

Otherwise Umbraco will not boot due to a duplicate index.

Corrected this.

resolves #1 