### PR TITLE
Upgrade Vendr version to 2.1.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Simple product reviews for Vendr, the eCommerce package for Umbrao v8+
 
 <img src="assets/screenshots/product-reviews-list.png" alt="" />
 
-## Instalation
+## Installation
 
 Add the following using statement to your product page view:
 

--- a/src/Vendr.Contrib.Reviews/Composing/VendrReviewsComposer.cs
+++ b/src/Vendr.Contrib.Reviews/Composing/VendrReviewsComposer.cs
@@ -3,6 +3,7 @@ using Vendr.Contrib.Reviews.Configuration;
 using Vendr.Contrib.Reviews.Extensions;
 using Vendr.Contrib.Reviews.Persistence;
 using Vendr.Contrib.Reviews.Services.Implement;
+using Vendr.Contrib.Reviews.Services;
 
 #if NETFRAMEWORK
 using Umbraco.Core;
@@ -36,7 +37,7 @@ namespace Vendr.Contrib.Reviews.Composing
             builder.RegisterUnique<IReviewRepositoryFactory, ReviewRepositoryFactory>();
 
             // Register services
-            builder.Register<ReviewService>(Lifetime.Singleton);
+            builder.Register<IReviewService, ReviewService>(Lifetime.Singleton);
 
             // Register event handlers
             builder.AddVendrReviewsEventHandlers();

--- a/src/Vendr.Contrib.Reviews/Events/Handlers/LogReviewAddedActivity.cs
+++ b/src/Vendr.Contrib.Reviews/Events/Handlers/LogReviewAddedActivity.cs
@@ -1,6 +1,7 @@
 ﻿using Vendr.Common.Events;
 using Vendr.Core.Adapters;
 using Vendr.Core.Services;
+using Vendr.Core.Models;
 
 #if NETFRAMEWORK
 using Umbraco.Core.Models.PublishedContent;
@@ -27,7 +28,12 @@ namespace Vendr.Contrib.Reviews.Events.Handlers
         {
             var culture = _variationContextAccessor.VariationContext.Culture;
 
-            var snapshot = _productAdapter.GetProductSnapshot(evt.Review.ProductReference, culture);
+            IProductSnapshot snapshot = null;
+#if NETFRAMEWORK
+            _productAdapter.GetProductSnapshot(evt.Review.StoreId, evt.Review.ProductReference, culture);
+#else
+            _productAdapter.GetProductSnapshot(evt.Review.ProductReference, culture);
+#endif
             if (snapshot == null)
                 return;
 

--- a/src/Vendr.Contrib.Reviews/Events/Handlers/LogReviewAddedActivity.cs
+++ b/src/Vendr.Contrib.Reviews/Events/Handlers/LogReviewAddedActivity.cs
@@ -28,12 +28,8 @@ namespace Vendr.Contrib.Reviews.Events.Handlers
         {
             var culture = _variationContextAccessor.VariationContext.Culture;
 
-            IProductSnapshot snapshot = null;
-#if NETFRAMEWORK
-            _productAdapter.GetProductSnapshot(evt.Review.StoreId, evt.Review.ProductReference, culture);
-#else
-            _productAdapter.GetProductSnapshot(evt.Review.ProductReference, culture);
-#endif
+            IProductSnapshot snapshot = _productAdapter.GetProductSnapshot(evt.Review.StoreId, evt.Review.ProductReference, culture);
+
             if (snapshot == null)
                 return;
 

--- a/src/Vendr.Contrib.Reviews/Vendr.Contrib.Reviews.csproj
+++ b/src/Vendr.Contrib.Reviews/Vendr.Contrib.Reviews.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
         <PackageReference Include="UmbracoCms.Web" Version="8.17.0" />
-        <PackageReference Include="Vendr.Umbraco.Startup" Version="2.0.0" />
+        <PackageReference Include="Vendr.Umbraco.Startup" Version="2.2.1" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">

--- a/src/Vendr.Contrib.Reviews/Vendr.Contrib.Reviews.csproj
+++ b/src/Vendr.Contrib.Reviews/Vendr.Contrib.Reviews.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
         <PackageReference Include="UmbracoCms.Web" Version="8.17.0" />
-        <PackageReference Include="Vendr.Umbraco.Startup" Version="2.2.1" />
+        <PackageReference Include="Vendr.Umbraco.Startup" Version="2.1.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">

--- a/src/Vendr.Contrib.Reviews/Vendr.Contrib.Reviews.csproj
+++ b/src/Vendr.Contrib.Reviews/Vendr.Contrib.Reviews.csproj
@@ -12,7 +12,7 @@
     <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
 	    <PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="9.0.0" />
         <PackageReference Include="Umbraco.Cms.Web.Website" Version="9.0.0" />
-        <PackageReference Include="Vendr.Umbraco.Startup" Version="2.0.0" />
+        <PackageReference Include="Vendr.Umbraco.Startup" Version="2.1.0" />
     </ItemGroup>
 
     <!-- Workaround for this bug (replace the analyzer name with the one you need to exclude (filename only, no extension) -->

--- a/src/Vendr.Contrib.Reviews/Web/Controllers/ReviewApiController.cs
+++ b/src/Vendr.Contrib.Reviews/Web/Controllers/ReviewApiController.cs
@@ -10,6 +10,7 @@ using Vendr.Contrib.Reviews.Services;
 using Vendr.Contrib.Reviews.Web.Dtos;
 using Vendr.Contrib.Reviews.Web.Dtos.Mappers;
 using Vendr.Core.Adapters;
+using Vendr.Core.Models;
 
 #if NETFRAMEWORK
 using System.Web.Http;
@@ -42,7 +43,7 @@ namespace Vendr.Contrib.Reviews.Web.Controllers
         public ReviewApiController(
             IReviewService reviewService,
             ILocalizedTextService textService,
-            IProductAdapter productAdapter)
+            IProductAdapter productAdapter):base()
         {
             _reviewService = reviewService;
             _textService = textService;
@@ -78,12 +79,17 @@ namespace Vendr.Contrib.Reviews.Web.Controllers
         }
 
         [HttpGet]
-        public Dictionary<string, string> GetProductData(string productReference, string languageIsoCode = null)
+        public Dictionary<string, string> GetProductData(Guid storeId, string productReference, string languageIsoCode = null)
         {
             if (string.IsNullOrEmpty(languageIsoCode))
                 languageIsoCode = Thread.CurrentThread.CurrentUICulture.Name;
 
-            var snapshot = _productAdapter.GetProductSnapshot(productReference, languageIsoCode);
+            IProductSnapshot snapshot = null;// _productAdapter.GetProductSnapshot(storeId, productReference, languageIsoCode);
+#if NETFRAMEWORK
+            _productAdapter.GetProductSnapshot(storeId, productReference, languageIsoCode);
+#else
+            _productAdapter.GetProductSnapshot(productReference, languageIsoCode);
+#endif
             if (snapshot == null)
                 return null;
 

--- a/src/Vendr.Contrib.Reviews/Web/Controllers/ReviewApiController.cs
+++ b/src/Vendr.Contrib.Reviews/Web/Controllers/ReviewApiController.cs
@@ -43,7 +43,7 @@ namespace Vendr.Contrib.Reviews.Web.Controllers
         public ReviewApiController(
             IReviewService reviewService,
             ILocalizedTextService textService,
-            IProductAdapter productAdapter):base()
+            IProductAdapter productAdapter)
         {
             _reviewService = reviewService;
             _textService = textService;

--- a/src/Vendr.Contrib.Reviews/Web/Controllers/ReviewApiController.cs
+++ b/src/Vendr.Contrib.Reviews/Web/Controllers/ReviewApiController.cs
@@ -84,12 +84,8 @@ namespace Vendr.Contrib.Reviews.Web.Controllers
             if (string.IsNullOrEmpty(languageIsoCode))
                 languageIsoCode = Thread.CurrentThread.CurrentUICulture.Name;
 
-            IProductSnapshot snapshot = null;// _productAdapter.GetProductSnapshot(storeId, productReference, languageIsoCode);
-#if NETFRAMEWORK
-            _productAdapter.GetProductSnapshot(storeId, productReference, languageIsoCode);
-#else
-            _productAdapter.GetProductSnapshot(productReference, languageIsoCode);
-#endif
+            IProductSnapshot snapshot = _productAdapter.GetProductSnapshot(storeId, productReference, languageIsoCode);
+
             if (snapshot == null)
                 return null;
 

--- a/src/Vendr.Contrib.Reviews/Web/UI/App_Plugins/VendrReviews/BackOffice/controllers/review-edit.controller.js
+++ b/src/Vendr.Contrib.Reviews/Web/UI/App_Plugins/VendrReviews/BackOffice/controllers/review-edit.controller.js
@@ -63,7 +63,7 @@
 
                 // Check to see if we have a product ref, and if so, try and fetch a product
                 if (review.productReference) {
-                    promises.push(vendrReviewsResource.getProductData(review.productReference, null));
+                    promises.push(vendrReviewsResource.getProductData(review.storeId, review.productReference, null));
                 }
                 else {
                     promises.push($q.resolve(null));

--- a/src/Vendr.Contrib.Reviews/Web/UI/App_Plugins/VendrReviews/BackOffice/resources/vendrreviews.resource.js
+++ b/src/Vendr.Contrib.Reviews/Web/UI/App_Plugins/VendrReviews/BackOffice/resources/vendrreviews.resource.js
@@ -72,10 +72,11 @@
                     "Failed to change review status");
             },
 
-            getProductData: function (productReference, languageIsoCode) {
+            getProductData: function (storeId, productReference, languageIsoCode) {
                 return umbRequestHelper.resourcePromise(
                     $http.get("/umbraco/backoffice/VendrReviews/ReviewApi/GetProductData", {
                         params: {
+                            storeId: storeId,
                             productReference: productReference,
                             languageIsoCode: languageIsoCode
                         }


### PR DESCRIPTION
Updated calls to `_productAdapter.GetProductSnapshot` to use the StoreID and pass through the chain where applicable.

@mattbrailsford not sure when this function was updated? Perhaps I can change this to target an earlier version than 2.2.1?