### PR TITLE
Updated to work on Umbraco 10.x with Vendr 3.x

### DIFF
--- a/build/NuGet/Vendr.Contrib.Reviews.nuspec
+++ b/build/NuGet/Vendr.Contrib.Reviews.nuspec
@@ -23,6 +23,10 @@
                 <dependency id="Umbraco.Cms.Web.Website" version="[9.0.0-rc002,9.9999999]" />
                 <dependency id="Vendr.Umbraco.Startup" version="[2.0.0,2.999999)" />
             </group>
+          <group targetFramework="net6.0">
+            <dependency id="Umbraco.Cms.Web.Website" version="[10.0.0,10.9999999]" />
+            <dependency id="Vendr.Umbraco.Startup" version="[3.0.0,3.999999)" />
+          </group>
         </dependencies>
     </metadata>
     <files>
@@ -32,6 +36,7 @@
         <!-- libs -->
         <file src="$ProjectDirectory$\bin\$Configuration$\net472\Vendr.Contrib.Reviews.dll" target="lib\net472\Vendr.Contrib.Reviews.dll" />
         <file src="$ProjectDirectory$\bin\$Configuration$\net5.0\Vendr.Contrib.Reviews.dll" target="lib\net5.0\Vendr.Contrib.Reviews.dll" />
+        <file src="$ProjectDirectory$\bin\$Configuration$\net6.0\Vendr.Contrib.Reviews.dll" target="lib\net6.0\Vendr.Contrib.Reviews.dll" />
 
         <!-- content -->
         <file src="$ArtifactFilesDirectory$\App_Plugins\**\*" target="App_Plugins" />
@@ -39,6 +44,7 @@
         <!-- UmbracoCms props and targets used to copy the content into the solution in .NET Core -->
         <file src="build\Vendr.Contrib.Reviews.targets" target="buildTransitive\" />
         <file src="build\Vendr.Contrib.Reviews.targets" target="build\net5.0\" />
+        <file src="build\Vendr.Contrib.Reviews.targets" target="build\net6.0\" />
         <!-- Install script used to copy the content into the solution in .NET Framework -->
         <file src="tools\install.ps1" target="tools\net472\" />
 

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>

--- a/src/Vendr.Contrib.Reviews/Migrations/V_1_0_0/CreateReviewTable.cs
+++ b/src/Vendr.Contrib.Reviews/Migrations/V_1_0_0/CreateReviewTable.cs
@@ -25,7 +25,12 @@ namespace Vendr.Contrib.Reviews.Migrations.V_1_0_0
         #endif
         {
             const string reviewTableName = Constants.DatabaseSchema.Tables.Review;
+#if NET6_0_OR_GREATER
+            const string storeTableName = Vendr.Persistence.Constants.DatabaseSchema.Tables.Store;
+#else
             const string storeTableName = Vendr.Infrastructure.Constants.DatabaseSchema.Tables.Store;
+#endif
+
 
             if (!TableExists(reviewTableName))
             {
@@ -34,16 +39,22 @@ namespace Vendr.Contrib.Reviews.Migrations.V_1_0_0
                 var nvarcharMaxType = SqlSyntax is SqlCeSyntaxProvider
                     ? "NTEXT"
                     : "NVARCHAR(MAX)";
-#else
+#elif NET5_0
                 var nvarcharMaxType = DatabaseType is NPoco.DatabaseTypes.SqlServerCEDatabaseType
                     ? "NTEXT"
+                    : "NVARCHAR(MAX)";
+#elif NET6_0_OR_GREATER
+                var nvarcharMaxType = DatabaseType is NPoco.DatabaseTypes.SqlServerCEDatabaseType
+                    ? "NTEXT"
+                    : DatabaseType is NPoco.DatabaseTypes.SQLiteDatabaseType 
+                    ? "TEXT"
                     : "NVARCHAR(MAX)";
 #endif
 
                 // Create table
                 Create.Table(reviewTableName)
                     .WithColumn("id").AsGuid().NotNullable().WithDefault(SystemMethods.NewGuid).PrimaryKey($"PK_{reviewTableName}")
-                    .WithColumn("storeId").AsGuid().NotNullable()
+                    .WithColumn("storeId").AsGuid().NotNullable().ForeignKey($"FK_{reviewTableName}_{storeTableName}", storeTableName, "id")
                     .WithColumn("productReference").AsString(255).NotNullable()
                     .WithColumn("customerReference").AsString(255).Nullable()
                     .WithColumn("rating").AsDecimal(2, 1).NotNullable()
@@ -56,12 +67,6 @@ namespace Vendr.Contrib.Reviews.Migrations.V_1_0_0
                     .WithColumn("status").AsInt32().NotNullable()
                     .WithColumn("createDate").AsDateTime().NotNullable()
                     .WithColumn("updateDate").AsDateTime().NotNullable()
-                    .Do();
-
-                // Foreign key constraints
-                Create.ForeignKey($"FK_{reviewTableName}_{storeTableName}")
-                    .FromTable(reviewTableName).ForeignColumn("storeId")
-                    .ToTable(storeTableName).PrimaryColumn("id")
                     .Do();
             }
         }

--- a/src/Vendr.Contrib.Reviews/Persistence/ReviewRepositoryFactory.cs
+++ b/src/Vendr.Contrib.Reviews/Persistence/ReviewRepositoryFactory.cs
@@ -5,24 +5,41 @@ using Vendr.Infrastructure;
 
 #if NETFRAMEWORK
 using Umbraco.Core.Scoping;
-#else
+#elif NET5_0
 using Umbraco.Cms.Core.Scoping;
+#elif NET6_0_OR_GREATER
+using Umbraco.Cms.Infrastructure.Scoping;
+using Vendr.Persistence;
 #endif
 
 namespace Vendr.Contrib.Reviews.Persistence
 {
     public class ReviewRepositoryFactory : IReviewRepositoryFactory
     {
-        private readonly IScopeAccessor _scopeAccessor;
+        //private readonly IScopeAccessor _scopeAccessor;
+        private readonly IScopeProvider _scopeProvider;
 
-        public ReviewRepositoryFactory(IScopeAccessor scopeAccessor)
+#if NET6_0_OR_GREATER
+        private readonly INPocoDatabaseProvider _dbProvider;
+        public ReviewRepositoryFactory(IScopeProvider scopeProvider, INPocoDatabaseProvider dbProvider)
+#else 
+        public ReviewRepositoryFactory(IScopeProvider scopeProvider)
+#endif
         {
-            _scopeAccessor = scopeAccessor;
+            _scopeProvider = scopeProvider;
+#if NET6_0
+            _dbProvider = dbProvider;
+#endif
         }
 
         public IReviewRepository CreateReviewRepository(IUnitOfWork uow)
         {
-            return new ReviewRepository((IDatabaseUnitOfWork)uow, _scopeAccessor.AmbientScope.SqlContext);
+#if NET6_0
+            return new ReviewRepository(_dbProvider, _scopeProvider.SqlContext);
+#else
+            return new ReviewRepository((IDatabaseUnitOfWork)uow, _scopeProvider.SqlContext);
+#endif
         }
+
     }
 }

--- a/src/Vendr.Contrib.Reviews/Vendr.Contrib.Reviews.csproj
+++ b/src/Vendr.Contrib.Reviews/Vendr.Contrib.Reviews.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-      <TargetFrameworks>net472;net5.0</TargetFrameworks>
+      <TargetFrameworks>net472;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
@@ -11,8 +11,14 @@
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
 	    <PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="9.0.0" />
-        <PackageReference Include="Umbraco.Cms.Web.Website" Version="9.0.0" />
-        <PackageReference Include="Vendr.Umbraco.Startup" Version="2.1.0" />
+      <PackageReference Include="Umbraco.Cms.Web.Website" Version="9.0.0" />
+      <PackageReference Include="Vendr.Umbraco.Startup" Version="2.1.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+      <PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="10.0.0" />
+      <PackageReference Include="Umbraco.Cms.Web.Website" Version="10.0.0" />
+      <PackageReference Include="Vendr.Umbraco.Startup" Version="3.0.0" />
     </ItemGroup>
 
     <!-- Workaround for this bug (replace the analyzer name with the one you need to exclude (filename only, no extension) -->

--- a/src/Vendr.Contrib.Reviews/Web/Controllers/ReviewTreeController.cs
+++ b/src/Vendr.Contrib.Reviews/Web/Controllers/ReviewTreeController.cs
@@ -45,13 +45,13 @@ namespace Vendr.Contrib.Reviews.Web.Controllers
         protected override TreeNodeCollection GetTreeNodes(string id, [ModelBinder(typeof(HttpQueryStringModelBinder))] FormDataCollection queryStrings) => null;
     }
 #else
-[Tree(
-        Vendr.Umbraco.Constants.Sections.Commerce,
-        Constants.Trees.Reviews.Alias,
-        //TreeGroup = "commerce",
-        TreeTitle = "Reviews",
-        SortOrder = 10,
-        TreeUse = TreeUse.None)]
+    [Tree(
+            Vendr.Umbraco.Constants.Sections.Commerce,
+            Constants.Trees.Reviews.Alias,
+            //TreeGroup = "commerce",
+            TreeTitle = "Reviews",
+            SortOrder = 10,
+            TreeUse = TreeUse.None)]
     [PluginController(Constants.Internals.PluginControllerName)]
     public sealed class ReviewTreeController : TreeController
     {
@@ -72,9 +72,7 @@ namespace Vendr.Contrib.Reviews.Web.Controllers
         protected override ActionResult<MenuItemCollection> GetMenuForNode(string id, [ModelBinder(typeof(HttpQueryStringModelBinder))] FormCollection queryStrings)
         {
             var menu = _menuItemCollectionFactory.Create();
-
             menu.Items.Add<ActionDelete>(_localizedTextService).LaunchDialogView("/app_plugins/vendrreviews/backoffice/views/dialogs/delete.html", "Delete");
-
             return menu;
         }
 


### PR DESCRIPTION
I've updated the reviews package for a private project, thought I'd contribute by creating an Umbraco 10 / Vendr 3 version.
I've tested the workings against the Vendr Demostore project installing from scratch.

One thing to keep in mind, the code assumes that when using .net6 you are also using umbraco 10, it's technically possible to run Umbraco 9 on .net6, but for this commit that would quite possibly cause dependency issues.
Any thoughts on this?